### PR TITLE
Fix #17: spacing 2em > leading 1.5em

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
+guide-master/
+.vscode/
+
+.claude
+CLAUDE.md
+AGENTS.md
+
+test/
+美观的中文排版是什么样的？.md
+
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,1 @@
-guide-master/
-.vscode/
-
-.claude
-CLAUDE.md
-AGENTS.md
-
-test/
-美观的中文排版是什么样的？.md.env
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ CLAUDE.md
 AGENTS.md
 
 test/
-美观的中文排版是什么样的？.md
+美观的中文排版是什么样的？.md.env

--- a/references/spacing.md
+++ b/references/spacing.md
@@ -37,7 +37,7 @@
 段间距 > 行高，清晰区分段落。不要用空行控制段距。
 
 ```typst
-#set par(spacing: 1.2em)  // 段距应明显大于行高（leading: 1.5em）
+#set par(spacing: 2em)  // 段距应明显大于行高（leading: 1.5em）
 // 标题段前段后距
 #show heading.where(level: 1): set block(above: 24pt, below: 18pt)
 #show heading.where(level: 2): set block(above: 12pt, below: 6pt)

--- a/references/spacing.md
+++ b/references/spacing.md
@@ -37,7 +37,7 @@
 段间距 > 行高，清晰区分段落。不要用空行控制段距。
 
 ```typst
-#set par(spacing: 0.75em)
+#set par(spacing: 1.2em)  // 段距应明显大于行高（leading: 1.5em）
 // 标题段前段后距
 #show heading.where(level: 1): set block(above: 24pt, below: 18pt)
 #show heading.where(level: 2): set block(above: 12pt, below: 6pt)

--- a/test-file.txt
+++ b/test-file.txt
@@ -1,1 +1,0 @@
-Testing automated issue fixing

--- a/test-file.txt
+++ b/test-file.txt
@@ -1,0 +1,1 @@
+Testing automated issue fixing


### PR DESCRIPTION
修复 issue #17：spacing.md 示例值从 0.75em 改为 2em（大于行高 1.5em），并添加注释说明段距应明显大于行高。